### PR TITLE
Add shorthand command `rn-ss-cleaner` as `rn-native-stylesheet-cleane…

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A utility tool to clean and optimize React Native stylesheets.",
   "main": "src/index.ts",
   "bin": {
-    "rn-native-stylesheet-cleaner": "dist/src/index.js"
+    "rn-native-stylesheet-cleaner": "dist/src/index.js",
+    "rn-ss-cleaner": "dist/src/index.js"
   },
   "scripts": {
     "build": "tsc",

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,12 @@ To use the RN Native Stylesheet Cleaner, navigate to your React Native project d
 rn-native-stylesheet-cleaner
 ```
 
+You can also use the shorthand command:
+
+```bash
+rn-ss-cleaner
+```
+
 This will scan your project for stylesheets, identify unused styles, and clean them up.
 
 ### Options
@@ -51,6 +57,7 @@ rn-native-stylesheet-cleaner --dry-run --verbose
 ```
 
 ## Warning
+
 Note: The formatting of the outputted code will be removed during the cleaning process. You will need to reformat the code after running the RN Native Stylesheet Cleaner. It is recommended to use a code formatter like Prettier to reformat your code.
 
 ## Contributing


### PR DESCRIPTION
## Description
This pull request includes changes to the `package.json` and `readme.md` files to add a shorthand command for the RN Native Stylesheet Cleaner tool. The most important changes are:

### New Shorthand Command:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L7-R8): Added a new shorthand command `rn-ss-cleaner` to the `bin` section.
* [`readme.md`](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R37-R42): Updated the documentation to include the new shorthand command `rn-ss-cleaner`.