### PR TITLE
Handle automatically detecting formatter and reformatting after cleaning

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,5 @@
 # RN Native Stylesheet Cleaner
+
 ![NPM Downloads](https://img.shields.io/npm/d18m/rn-native-stylesheet-cleaner)
 
 This project is a utility tool designed to clean and optimize React Native stylesheets. It helps in removing unused styles and organizing the stylesheet for better readability and maintainability.
@@ -48,6 +49,7 @@ This will scan your project for stylesheets, identify unused styles, and clean t
 - `-d, --directory <path>`: Directory to parse (default: `src`)
 - `-i, --include <patterns>`: File patterns to include (default: `**/*.{jsx,tsx}`)
 - `-e, --exclude <patterns>`: File patterns to exclude (default: `''`)
+- `--no-format`: Run the cleaner without reformatting the output.
 - `--dry-run`: Run the cleaner without making any changes, just to see what would be cleaned.
 - `--verbose`: Output detailed information during the cleaning process.
 
@@ -59,7 +61,7 @@ rn-native-stylesheet-cleaner --dry-run --verbose
 
 ## Warning
 
-Note: The formatting of the outputted code will be removed during the cleaning process. You will need to reformat the code after running the RN Native Stylesheet Cleaner. It is recommended to use a code formatter like Prettier to reformat your code.
+Note: The formatting of the outputted code will be initially removed during the cleaning process. However, if you have Prettier or Biome installed, the code will be reformatted automatically. The reformatting behavior is still experimental, and extra whitespace may still be stripped. You can turn off this behavior by using the `--no-format` flag if you prefer to handle formatting manually.
 
 ## Contributing
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,47 @@
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const findConfigFile = (dir: string, filenames: string[]) => {
+  for (const filename of filenames) {
+    const filePath = path.join(dir, filename);
+    if (fs.existsSync(filePath)) {
+      return filePath;
+    }
+  }
+  return null;
+};
+
+export const detectFormatter = (directory: string) => {
+  const prettierConfigs = [".prettierrc", ".prettierrc.js", ".prettierrc.json", "prettier.config.js"];
+  const biomeConfigs = ["biome.json", "biome.jsonc", "biome.config.json"];
+
+  const prettierConfigPath = findConfigFile(directory, prettierConfigs);
+  if (prettierConfigPath) return "prettier";
+
+  const biomeConfigPath = findConfigFile(directory, biomeConfigs);
+  if (biomeConfigPath) return "biome";
+
+  return null;
+};
+
+const formatWithBiome = (filePath: string) => {
+  execSync(`npx biome format --write ${filePath}`, { stdio: "inherit" });
+};
+
+export const formatFile = (filePath: string, formatter: string | null) => {
+  try {
+    if (formatter === "prettier") {
+      const prettier = require("prettier");
+      const prettierConfig = prettier.resolveConfig.sync(filePath) || {};
+      prettierConfig.parser = filePath.endsWith(".tsx") ? "tsx" : "babel";
+      const code = fs.readFileSync(filePath, "utf-8");
+      const formattedCode = prettier.format(code, prettierConfig);
+      fs.writeFileSync(filePath, formattedCode, "utf-8");
+    } else if (formatter === "biome") {
+      formatWithBiome(filePath);
+    }
+  } catch (err) {
+    console.error(err);
+  }
+};


### PR DESCRIPTION
## Description
This pull request introduces several enhancements to the RN Native Stylesheet Cleaner project, including the addition of a new option to control code formatting and the implementation of automatic code formatting detection and application. Below are the most important changes:

### Documentation Updates:
* Updated the documentation to include the new `--no-format` option and explain the experimental automatic code formatting feature. [[1]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R52) [[2]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L62-R64)

### Code Enhancements:
* Added the `--no-format` option to the command-line interface in `src/index.ts`.
* Implemented automatic detection of code formatters (Prettier or Biome) and applied formatting based on the detected formatter in `src/index.ts`. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R36-R46) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R127-R129)
* Introduced the `detectFormatter` and `formatFile` functions in a new `src/utils.ts` file to handle the detection and application of code formatting.

These changes improve the usability of the tool by allowing users to control code formatting behavior and automate the formatting process based on the presence of configuration files.